### PR TITLE
Changes to embeds, Changes to reaction timing

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,29 +13,31 @@ client.remove_command('help')
 @client.event
 async def on_ready():
 	print('Logged in as {0.user}'.format(client))
-	await client.change_presence(activity=discord.Game(name='/help | github.com/noor0x07/onyxium-bot'))
+	await client.change_presence(activity=discord.Game(name="/help | I'm in " + str(len(client.guilds)) + " servers"))
 
 
 @client.command(pass_context=True)
 async def help(ctx):
 	author = ctx.message.author
-	embed = discord.Embed(title="onyxium", description="help commands", color=0x3eb489)
-	embed.add_field(name="ping", value="Bot latency", inline=True)
-	embed.add_field(name="uptime", value="see bot uptime", inline=True)
-	embed.add_field(name="ip", value="see specific ip details", inline=True)
-	embed.add_field(name="kick", value="kick a user from server", inline=True)
-	embed.add_field(name="ban", value="ban a user from server", inline=True)
-	embed.add_field(name="unban", value="unban a user from server", inline=True)
-	embed.add_field(name="purge", value="purge a number of messages", inline=True)
-	embed.add_field(name="whois", value="show info about an account", inline=True)
-	embed.add_field(name="avatar", value="see a user's avatar", inline=True)
-
-	await author.send(embed=embed)
-
+	embed = discord.Embed(title="Onyxium", description="This is a list of all the current commands", color=0x3eb489)
+	embed.add_field(name="```ping```",value="Bot latency", inline=False)
+	embed.add_field(name="```uptime```", value="see bot uptime", inline=False)
+	embed.add_field(name="```ip```", value="see specific ip details", inline=False)
+	embed.add_field(name="```kick```", value="kick a user from server", inline=False)
+	embed.add_field(name="```ban```", value="ban a user from server", inline=False)
+	embed.add_field(name="```unban```", value="unban a user from server", inline=False)
+	embed.add_field(name="```purge```", value="purge a number of messages", inline=False)
+	embed.add_field(name="```whois```", value="show info about an account", inline=False)
+	embed.add_field(name="```avatar```", value="see a user's avatar", inline=False)
+	embed.add_field(name="```info```",value="info about bot", inline=False)
+	embed.set_footer(text='https://github.com/noor0x07/onyxium-bot')
 	last_message = ctx.channel.last_message_id
 	message = await ctx.channel.fetch_message(int(last_message))
 
 	await message.add_reaction(emoji="<:checkedbox:781556049953423373>")  # will probably mess up later on
+	
+	await author.send(embed=embed)
+
 
 
 @client.command()
@@ -119,6 +121,27 @@ async def avatar(ctx, member: discord.Member):
 	show_avatar = discord.Embed(color=0x3eb489, description=f":bust_in_silhouette: **{member.display_name}**'s avatar : ")
 	show_avatar.set_image(url='{}'.format(member.avatar_url))
 	await ctx.send(embed=show_avatar)
+
+	
+@client.command(aliases=['about', 'info','links'])
+async def invite(ctx):
+	embed = discord.Embed(
+		title = 'Onyxium',
+		description = 'Information and links',
+		colour=0x3eb489
+
+	)
+
+	embed.set_footer(text='')
+	embed.set_thumbnail(url= 'https://cdn.discordapp.com/avatars/772944435020431392/ecfa2b9967914c73faead132eb7b26f6.png?size=128')
+	embed.add_field(name='Invite Link', value='[here](https://discord.com/api/oauth2/authorize?client_id=772944435020431392&permissions=8&scope=bot)', inline=False)
+	embed.add_field(name='GitHub Repo', value='[here](https://github.com/noor0x07/onyxium-bot)', inline=False)
+	embed.add_field(name='Discord Link', value='[here](https://discord.gg/adCPaYNEGv)', inline=False)
+	await ctx.send(embed=embed)
+
+
+
+
 
 
 client.run(token)


### PR DESCRIPTION
Created a new command called "invite" which links an invite for the bot, link to the repo, and a link to the discord server.
Changed the way "help" command is organized to make it look nicer and less cluttered.
Switched the reaction to go before the message to author on "help" command